### PR TITLE
fix: prevent Lenis from intercepting scroll in code panels

### DIFF
--- a/src/components/interactive/CodeWave.tsx
+++ b/src/components/interactive/CodeWave.tsx
@@ -131,7 +131,8 @@ function CodePanel({ step }: { step: CodeStep }) {
   return (
     <div
       ref={containerRef}
-      className="h-full overflow-y-auto overscroll-contain"
+      className="absolute inset-0 overflow-y-auto overscroll-contain"
+      data-lenis-prevent
     >
       <pre
         className="px-4 text-[12px] leading-[1.6] font-mono sm:px-5"

--- a/src/components/interactive/WebWave.tsx
+++ b/src/components/interactive/WebWave.tsx
@@ -100,7 +100,7 @@ function SourcePanel({ code }: { code: string }) {
   const lines = code.split('\n')
 
   return (
-    <div className="h-full overflow-auto overscroll-contain">
+    <div className="h-full overflow-auto overscroll-contain" data-lenis-prevent>
       <pre className="px-4 py-4 text-[12px] leading-[1.6] font-mono sm:px-5">
         <code>
           {lines.map((line, i) => (


### PR DESCRIPTION
## Summary
- 修复教程页面左侧代码面板无法滚动的问题（滚动事件被 Lenis 拦截滚动到整页而非代码区）
- 为 CodePanel 和 SourcePanel 滚动容器添加 `data-lenis-prevent` 属性，使其退出 Lenis 的滚动劫持
- 同时修复 CodePanel 的高度链问题：`h-full` 改为 `absolute inset-0`，确保 `overflow-y-auto` 有确定的高度约束

## Test plan
- [ ] 桌面端打开任意教程页，鼠标悬停左侧代码面板滚动，代码应独立滚动而非带动整页
- [ ] WebWave 的 Source 视图仍能正常内部滚动
- [ ] 移动端不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)